### PR TITLE
use wall-clock timer

### DIFF
--- a/benchmarks/__init__.py
+++ b/benchmarks/__init__.py
@@ -1,4 +1,5 @@
 import inspect
+import timeit
 
 # Ensure that CuPy and cuDNN are available.
 import cupy  # NOQA
@@ -10,6 +11,9 @@ class BenchmarkBase(object):
 
     See also: http://asv.readthedocs.io/en/v0.2.1/writing_benchmarks.html
     """
+
+    # Use wall-clock timer instead of CPU timer
+    timer = timeit.default_timer
 
     # Allow up to 10 minutes, instead of the default (60 seconds).
     timeout = 600


### PR DESCRIPTION
By default ASV measures CPU time, not wall-clock time.
http://asv.readthedocs.io/en/latest/writing_benchmarks.html#timing

This was inappropriate especially when comparing GPU and CPU performance, because NumPy (with MKL/BLAS) or iDeep utilizes multiple-threads, which makes the time much larger than wall-clock time.